### PR TITLE
Check style is now operational with maven.

### DIFF
--- a/CheckStyle.xml
+++ b/CheckStyle.xml
@@ -95,9 +95,6 @@ The CheckStyle configuration for the discover project
       <property name="severity" value="error"/>
     </module>
     <module name="PackageAnnotation"/>
-    <module name="AnnotationLocation"/>
-    <module name="NonEmptyAtclauseDescription"/>
-    <module name="JavadocParagraph"/>
     <module name="ImportOrder">
       <property name="separated" value="true"/>
       <property name="sortStaticImportsAlphabetically" value="true"/>
@@ -114,6 +111,9 @@ The CheckStyle configuration for the discover project
     <module name="Indentation"/>
     <module name="EmptyLineSeparator"/>
     <module name="NPathComplexity"/>
+    <module name="AnnotationLocation"/>
+    <module name="NonEmptyAtclauseDescription"/>
+    <module name="JavadocParagraph"/>
   </module>
   <module name="JavadocPackage"/>
   <module name="NewlineAtEndOfFile"/>
@@ -121,6 +121,7 @@ The CheckStyle configuration for the discover project
   <module name="FileLength"/>
   <module name="FileTabCharacter">
     <property name="severity" value="ignore"/>
+    <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
   </module>
   <module name="RegexpSingleline">
     <property name="severity" value="ignore"/>

--- a/CheckStyleForMaven.xml
+++ b/CheckStyleForMaven.xml
@@ -5,9 +5,9 @@
     This configuration file was written by the eclipse-cs plugin configuration editor
 -->
 <!--
-    Checkstyle-Configuration: Discover
+    Checkstyle-Configuration: Discover Maven
     Description: 
-The CheckStyle configuration for the discover project
+The CheckStyle file explicitly for maven usage. It is roughly the same as the other CheckStyle configuration but contains less checks, because the removed checks are added in CheckStyle 6.0 (or later). Mavens latest CheckStyle plugin is still at CheckStyle 5.8. See http://checkstyle.sourceforge.net/releasenotes.html for more information.  Please ignore any and all errors regarding java 8 syntax when using this file for maven as java 8 support was added to CheckStyle 5.9.
 -->
 <module name="Checker">
   <property name="severity" value="warning"/>
@@ -99,7 +99,6 @@ The CheckStyle configuration for the discover project
     <module name="PackageAnnotation"/>
     <module name="ImportOrder">
       <property name="separated" value="true"/>
-      <property name="sortStaticImportsAlphabetically" value="true"/>
     </module>
     <module name="GenericWhitespace"/>
     <module name="CovariantEquals"/>
@@ -113,13 +112,6 @@ The CheckStyle configuration for the discover project
     <module name="Indentation"/>
     <module name="EmptyLineSeparator"/>
     <module name="NPathComplexity"/>
-    <module name="AnnotationLocation"/>
-    <module name="NonEmptyAtclauseDescription"/>
-    <module name="JavadocParagraph"/>
-  </module>
-  <module name="JavadocPackage">
-    <property name="severity" value="ignore"/>
-    <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
   </module>
   <module name="NewlineAtEndOfFile"/>
   <module name="Translation"/>

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@ under the License.
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>2.14</version>
                 <configuration>
-                	<configLocation>checkstyle.xml</configLocation>
+                	<configLocation>CheckStyleForMaven.xml</configLocation>
                     <failOnViolation>false</failOnViolation>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,7 @@ under the License.
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>2.14</version>
                 <configuration>
+                	<configLocation>checkstyle.xml</configLocation>
                     <failOnViolation>false</failOnViolation>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Maven is now using our own CheckStyle configuration. However since the latest maven check style plugin is only on check style version 5.8 there is a different file for it, due to missing checks in this version. Although this new file is good enough for the tests, the old file contains more checks that are considered good practice. Please only review to this branch by telling if the check style now works with maven on your machines, since that is the most important consideration for this.

Documentation has been updated and is currently available on https://github.com/contextproject/docs on commit b687167d35c5e99d61ad9d96a7d9966503dd5ab1.
